### PR TITLE
LaSR integration changes

### DIFF
--- a/src/Population.jl
+++ b/src/Population.jl
@@ -167,7 +167,7 @@ const CACHED_WEIGHTS =
         PerThreadCache{Dict{Tuple{Int,Float32},typeof(test_weights)}}()
     end
 
-@unstable function get_tournament_selection_weights(@nospecialize(options::Options))
+@unstable function get_tournament_selection_weights(@nospecialize(options::AbstractOptions))
     n = options.tournament_selection_n
     p = options.tournament_selection_p
     # Computing the weights for the tournament becomes quite expensive,


### PR DESCRIPTION
Stress testing SymbolicRegression.jl's customization feature with LaSR. I'll open a PR in the main repo once LaSR's performance is up to task.

List of changes so far:

1.  Change `get_tournament_selection_weights` argument type to AbstractOptions (f232c43) `get_tournament_selection_weights` only accepts `options::Options`. This created a bottleneck for LaSR (or any other SymbolicRegression.jl customization) that relies on multiple dispatch on subtypes of `AbstractOptions`. Changing the function signature _shouldn't_ impact the test performance of SymbolicRegression.jl.